### PR TITLE
Student 계정 생성 연동 API base 구현

### DIFF
--- a/api/delivery/http/handler/student_handler.go
+++ b/api/delivery/http/handler/student_handler.go
@@ -1,0 +1,11 @@
+package handler
+
+import "github.com/Wanted-Linx/linx-backend/api/domain"
+
+type StudentHandler struct {
+	studentService domain.StudentService
+}
+
+func NewStudentHandler(studentService domain.StudentService) *StudentHandler {
+	return &StudentHandler{studentService: studentService}
+}

--- a/api/delivery/http/router.go
+++ b/api/delivery/http/router.go
@@ -2,8 +2,9 @@ package http
 
 import "github.com/Wanted-Linx/linx-backend/api/delivery/http/handler"
 
-func initRouter(userHandler *handler.UserHandler) {
+func initRouter(userHandler *handler.UserHandler, studentHandler *handler.StudentHandler) {
 	userRouter(userHandler)
+	studentRouter(studentHandler)
 }
 
 func userRouter(userHandler *handler.UserHandler) {
@@ -11,4 +12,8 @@ func userRouter(userHandler *handler.UserHandler) {
 	group.POST("/signup", userHandler.SignUp)
 	group.POST("/login", userHandler.Login)
 	group.GET("/me", userHandler.GetUserByID)
+}
+func studentRouter(studentHandler *handler.StudentHandler) {
+	_ = e.Group("/students")
+
 }

--- a/api/delivery/http/server.go
+++ b/api/delivery/http/server.go
@@ -8,7 +8,7 @@ import (
 
 var e *echo.Echo
 
-func NewServer(userHandler *handler.UserHandler) *echo.Echo {
+func NewServer(userHandler *handler.UserHandler, studentHandler *handler.StudentHandler) *echo.Echo {
 	e = echo.New()
 	e.HTTPErrorHandler = httpErrorHandler
 	e.Use(middleware.Logger())
@@ -19,6 +19,6 @@ func NewServer(userHandler *handler.UserHandler) *echo.Echo {
 		AllowMethods: []string{echo.GET, echo.HEAD, echo.PUT, echo.PATCH, echo.POST, echo.DELETE},
 	}))
 
-	initRouter(userHandler)
+	initRouter(userHandler, studentHandler)
 	return e
 }

--- a/api/domain/student.go
+++ b/api/domain/student.go
@@ -1,4 +1,34 @@
 package domain
 
+import "github.com/Wanted-Linx/linx-backend/api/ent"
+
+type StudentDto struct {
+	ID             int     `json:"id"`
+	Name           string  `json:"name"`
+	University     string  `json:"university"`
+	InterestedType *string `json:"interested_type"`
+	ProfileLink    *string `json:"profile_link"`
+	ProfileImage   *string `json:"profile_image"`
+}
+
 type Student struct {
+}
+type StudentService interface {
+	Save(userID int, reqSignup *SignUpRequest) (*StudentDto, error)
+	GetStudentByID(studentID int) (*StudentDto, error)
+}
+type StudentRepository interface {
+	Save(reqStudent *ent.Student) (*ent.Student, error)
+	GetByID(studentID int, reqStudent *ent.Student) (*ent.Student, error)
+	// GetAll(clubID int) ([]*ent.Student, error)
+}
+
+func StudentToDto(src *ent.Student) *StudentDto {
+	return &StudentDto{
+		ID:           src.Edges.User.ID,
+		Name:         src.Name,
+		University:   src.University,
+		ProfileLink:  src.ProfileLink,
+		ProfileImage: src.ProfileImage,
+	}
 }

--- a/api/domain/user.go
+++ b/api/domain/user.go
@@ -9,10 +9,12 @@ type UserDto struct {
 }
 
 type SignUpRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
+	Email          string `json:"email"`
+	Password       string `json:"password"`
+	Name           string `json:"name"`
+	BusinessNumber string `json:"business_number"`
+	University     string `json:"university"`
+	Kind           string `json:"kind"`
 }
 
 type LoginRequest struct {

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -13,8 +13,9 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "university", Type: field.TypeString},
-		{Name: "profile_link", Type: field.TypeString},
-		{Name: "profile_image", Type: field.TypeString},
+		{Name: "interested_type", Type: field.TypeString, Nullable: true},
+		{Name: "profile_link", Type: field.TypeString, Nullable: true},
+		{Name: "profile_image", Type: field.TypeString, Nullable: true},
 		{Name: "user_student", Type: field.TypeInt, Nullable: true},
 	}
 	// StudentsTable holds the schema information for the "students" table.
@@ -25,7 +26,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "students_users_student",
-				Columns:    []*schema.Column{StudentsColumns[5]},
+				Columns:    []*schema.Column{StudentsColumns[6]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -30,19 +30,20 @@ const (
 // StudentMutation represents an operation that mutates the Student nodes in the graph.
 type StudentMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *int
-	name          *string
-	university    *string
-	profile_link  *string
-	profile_image *string
-	clearedFields map[string]struct{}
-	user          *int
-	cleareduser   bool
-	done          bool
-	oldValue      func(context.Context) (*Student, error)
-	predicates    []predicate.Student
+	op              Op
+	typ             string
+	id              *int
+	name            *string
+	university      *string
+	interested_type *string
+	profile_link    *string
+	profile_image   *string
+	clearedFields   map[string]struct{}
+	user            *int
+	cleareduser     bool
+	done            bool
+	oldValue        func(context.Context) (*Student, error)
+	predicates      []predicate.Student
 }
 
 var _ ent.Mutation = (*StudentMutation)(nil)
@@ -113,6 +114,12 @@ func (m StudentMutation) Tx() (*Tx, error) {
 	tx := &Tx{config: m.config}
 	tx.init()
 	return tx, nil
+}
+
+// SetID sets the value of the id field. Note that this
+// operation is only accepted on creation of Student entities.
+func (m *StudentMutation) SetID(id int) {
+	m.id = &id
 }
 
 // ID returns the ID value in the mutation. Note that the ID is only available
@@ -196,6 +203,55 @@ func (m *StudentMutation) ResetUniversity() {
 	m.university = nil
 }
 
+// SetInterestedType sets the "interested_type" field.
+func (m *StudentMutation) SetInterestedType(s string) {
+	m.interested_type = &s
+}
+
+// InterestedType returns the value of the "interested_type" field in the mutation.
+func (m *StudentMutation) InterestedType() (r string, exists bool) {
+	v := m.interested_type
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInterestedType returns the old "interested_type" field's value of the Student entity.
+// If the Student object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *StudentMutation) OldInterestedType(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldInterestedType is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldInterestedType requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInterestedType: %w", err)
+	}
+	return oldValue.InterestedType, nil
+}
+
+// ClearInterestedType clears the value of the "interested_type" field.
+func (m *StudentMutation) ClearInterestedType() {
+	m.interested_type = nil
+	m.clearedFields[student.FieldInterestedType] = struct{}{}
+}
+
+// InterestedTypeCleared returns if the "interested_type" field was cleared in this mutation.
+func (m *StudentMutation) InterestedTypeCleared() bool {
+	_, ok := m.clearedFields[student.FieldInterestedType]
+	return ok
+}
+
+// ResetInterestedType resets all changes to the "interested_type" field.
+func (m *StudentMutation) ResetInterestedType() {
+	m.interested_type = nil
+	delete(m.clearedFields, student.FieldInterestedType)
+}
+
 // SetProfileLink sets the "profile_link" field.
 func (m *StudentMutation) SetProfileLink(s string) {
 	m.profile_link = &s
@@ -213,7 +269,7 @@ func (m *StudentMutation) ProfileLink() (r string, exists bool) {
 // OldProfileLink returns the old "profile_link" field's value of the Student entity.
 // If the Student object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *StudentMutation) OldProfileLink(ctx context.Context) (v string, err error) {
+func (m *StudentMutation) OldProfileLink(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, fmt.Errorf("OldProfileLink is only allowed on UpdateOne operations")
 	}
@@ -227,9 +283,22 @@ func (m *StudentMutation) OldProfileLink(ctx context.Context) (v string, err err
 	return oldValue.ProfileLink, nil
 }
 
+// ClearProfileLink clears the value of the "profile_link" field.
+func (m *StudentMutation) ClearProfileLink() {
+	m.profile_link = nil
+	m.clearedFields[student.FieldProfileLink] = struct{}{}
+}
+
+// ProfileLinkCleared returns if the "profile_link" field was cleared in this mutation.
+func (m *StudentMutation) ProfileLinkCleared() bool {
+	_, ok := m.clearedFields[student.FieldProfileLink]
+	return ok
+}
+
 // ResetProfileLink resets all changes to the "profile_link" field.
 func (m *StudentMutation) ResetProfileLink() {
 	m.profile_link = nil
+	delete(m.clearedFields, student.FieldProfileLink)
 }
 
 // SetProfileImage sets the "profile_image" field.
@@ -249,7 +318,7 @@ func (m *StudentMutation) ProfileImage() (r string, exists bool) {
 // OldProfileImage returns the old "profile_image" field's value of the Student entity.
 // If the Student object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *StudentMutation) OldProfileImage(ctx context.Context) (v string, err error) {
+func (m *StudentMutation) OldProfileImage(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, fmt.Errorf("OldProfileImage is only allowed on UpdateOne operations")
 	}
@@ -263,9 +332,22 @@ func (m *StudentMutation) OldProfileImage(ctx context.Context) (v string, err er
 	return oldValue.ProfileImage, nil
 }
 
+// ClearProfileImage clears the value of the "profile_image" field.
+func (m *StudentMutation) ClearProfileImage() {
+	m.profile_image = nil
+	m.clearedFields[student.FieldProfileImage] = struct{}{}
+}
+
+// ProfileImageCleared returns if the "profile_image" field was cleared in this mutation.
+func (m *StudentMutation) ProfileImageCleared() bool {
+	_, ok := m.clearedFields[student.FieldProfileImage]
+	return ok
+}
+
 // ResetProfileImage resets all changes to the "profile_image" field.
 func (m *StudentMutation) ResetProfileImage() {
 	m.profile_image = nil
+	delete(m.clearedFields, student.FieldProfileImage)
 }
 
 // SetUserID sets the "user" edge to the User entity by id.
@@ -326,12 +408,15 @@ func (m *StudentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *StudentMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.name != nil {
 		fields = append(fields, student.FieldName)
 	}
 	if m.university != nil {
 		fields = append(fields, student.FieldUniversity)
+	}
+	if m.interested_type != nil {
+		fields = append(fields, student.FieldInterestedType)
 	}
 	if m.profile_link != nil {
 		fields = append(fields, student.FieldProfileLink)
@@ -351,6 +436,8 @@ func (m *StudentMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case student.FieldUniversity:
 		return m.University()
+	case student.FieldInterestedType:
+		return m.InterestedType()
 	case student.FieldProfileLink:
 		return m.ProfileLink()
 	case student.FieldProfileImage:
@@ -368,6 +455,8 @@ func (m *StudentMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldName(ctx)
 	case student.FieldUniversity:
 		return m.OldUniversity(ctx)
+	case student.FieldInterestedType:
+		return m.OldInterestedType(ctx)
 	case student.FieldProfileLink:
 		return m.OldProfileLink(ctx)
 	case student.FieldProfileImage:
@@ -394,6 +483,13 @@ func (m *StudentMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUniversity(v)
+		return nil
+	case student.FieldInterestedType:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInterestedType(v)
 		return nil
 	case student.FieldProfileLink:
 		v, ok := value.(string)
@@ -438,7 +534,17 @@ func (m *StudentMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *StudentMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(student.FieldInterestedType) {
+		fields = append(fields, student.FieldInterestedType)
+	}
+	if m.FieldCleared(student.FieldProfileLink) {
+		fields = append(fields, student.FieldProfileLink)
+	}
+	if m.FieldCleared(student.FieldProfileImage) {
+		fields = append(fields, student.FieldProfileImage)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -451,6 +557,17 @@ func (m *StudentMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *StudentMutation) ClearField(name string) error {
+	switch name {
+	case student.FieldInterestedType:
+		m.ClearInterestedType()
+		return nil
+	case student.FieldProfileLink:
+		m.ClearProfileLink()
+		return nil
+	case student.FieldProfileImage:
+		m.ClearProfileImage()
+		return nil
+	}
 	return fmt.Errorf("unknown Student nullable field %s", name)
 }
 
@@ -463,6 +580,9 @@ func (m *StudentMutation) ResetField(name string) error {
 		return nil
 	case student.FieldUniversity:
 		m.ResetUniversity()
+		return nil
+	case student.FieldInterestedType:
+		m.ResetInterestedType()
 		return nil
 	case student.FieldProfileLink:
 		m.ResetProfileLink()

--- a/api/ent/schema/student.go
+++ b/api/ent/schema/student.go
@@ -14,10 +14,12 @@ type Student struct {
 // Fields of the Student.
 func (Student) Fields() []ent.Field {
 	return []ent.Field{
+		field.Int("id"),
 		field.String("name"),
 		field.String("university"),
-		field.String("profile_link"),
-		field.String("profile_image"),
+		field.String("interested_type").Optional().Nillable(),
+		field.String("profile_link").Optional().Nillable(),
+		field.String("profile_image").Optional().Nillable(),
 	}
 }
 

--- a/api/ent/schema/user.go
+++ b/api/ent/schema/user.go
@@ -26,5 +26,6 @@ func (User) Fields() []ent.Field {
 func (User) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("student", Student.Type),
+		edge.To("company", Student.Type),
 	}
 }

--- a/api/ent/student.go
+++ b/api/ent/student.go
@@ -20,10 +20,12 @@ type Student struct {
 	Name string `json:"name,omitempty"`
 	// University holds the value of the "university" field.
 	University string `json:"university,omitempty"`
+	// InterestedType holds the value of the "interested_type" field.
+	InterestedType *string `json:"interested_type,omitempty"`
 	// ProfileLink holds the value of the "profile_link" field.
-	ProfileLink string `json:"profile_link,omitempty"`
+	ProfileLink *string `json:"profile_link,omitempty"`
 	// ProfileImage holds the value of the "profile_image" field.
-	ProfileImage string `json:"profile_image,omitempty"`
+	ProfileImage *string `json:"profile_image,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the StudentQuery when eager-loading is set.
 	Edges        StudentEdges `json:"edges"`
@@ -60,7 +62,7 @@ func (*Student) scanValues(columns []string) ([]interface{}, error) {
 		switch columns[i] {
 		case student.FieldID:
 			values[i] = new(sql.NullInt64)
-		case student.FieldName, student.FieldUniversity, student.FieldProfileLink, student.FieldProfileImage:
+		case student.FieldName, student.FieldUniversity, student.FieldInterestedType, student.FieldProfileLink, student.FieldProfileImage:
 			values[i] = new(sql.NullString)
 		case student.ForeignKeys[0]: // user_student
 			values[i] = new(sql.NullInt64)
@@ -97,17 +99,26 @@ func (s *Student) assignValues(columns []string, values []interface{}) error {
 			} else if value.Valid {
 				s.University = value.String
 			}
+		case student.FieldInterestedType:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field interested_type", values[i])
+			} else if value.Valid {
+				s.InterestedType = new(string)
+				*s.InterestedType = value.String
+			}
 		case student.FieldProfileLink:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field profile_link", values[i])
 			} else if value.Valid {
-				s.ProfileLink = value.String
+				s.ProfileLink = new(string)
+				*s.ProfileLink = value.String
 			}
 		case student.FieldProfileImage:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field profile_image", values[i])
 			} else if value.Valid {
-				s.ProfileImage = value.String
+				s.ProfileImage = new(string)
+				*s.ProfileImage = value.String
 			}
 		case student.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -153,10 +164,18 @@ func (s *Student) String() string {
 	builder.WriteString(s.Name)
 	builder.WriteString(", university=")
 	builder.WriteString(s.University)
-	builder.WriteString(", profile_link=")
-	builder.WriteString(s.ProfileLink)
-	builder.WriteString(", profile_image=")
-	builder.WriteString(s.ProfileImage)
+	if v := s.InterestedType; v != nil {
+		builder.WriteString(", interested_type=")
+		builder.WriteString(*v)
+	}
+	if v := s.ProfileLink; v != nil {
+		builder.WriteString(", profile_link=")
+		builder.WriteString(*v)
+	}
+	if v := s.ProfileImage; v != nil {
+		builder.WriteString(", profile_image=")
+		builder.WriteString(*v)
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/api/ent/student/student.go
+++ b/api/ent/student/student.go
@@ -11,6 +11,8 @@ const (
 	FieldName = "name"
 	// FieldUniversity holds the string denoting the university field in the database.
 	FieldUniversity = "university"
+	// FieldInterestedType holds the string denoting the interested_type field in the database.
+	FieldInterestedType = "interested_type"
 	// FieldProfileLink holds the string denoting the profile_link field in the database.
 	FieldProfileLink = "profile_link"
 	// FieldProfileImage holds the string denoting the profile_image field in the database.
@@ -33,6 +35,7 @@ var Columns = []string{
 	FieldID,
 	FieldName,
 	FieldUniversity,
+	FieldInterestedType,
 	FieldProfileLink,
 	FieldProfileImage,
 }

--- a/api/ent/student/where.go
+++ b/api/ent/student/where.go
@@ -105,6 +105,13 @@ func University(v string) predicate.Student {
 	})
 }
 
+// InterestedType applies equality check predicate on the "interested_type" field. It's identical to InterestedTypeEQ.
+func InterestedType(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldInterestedType), v))
+	})
+}
+
 // ProfileLink applies equality check predicate on the "profile_link" field. It's identical to ProfileLinkEQ.
 func ProfileLink(v string) predicate.Student {
 	return predicate.Student(func(s *sql.Selector) {
@@ -341,6 +348,131 @@ func UniversityContainsFold(v string) predicate.Student {
 	})
 }
 
+// InterestedTypeEQ applies the EQ predicate on the "interested_type" field.
+func InterestedTypeEQ(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeNEQ applies the NEQ predicate on the "interested_type" field.
+func InterestedTypeNEQ(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeIn applies the In predicate on the "interested_type" field.
+func InterestedTypeIn(vs ...string) predicate.Student {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Student(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldInterestedType), v...))
+	})
+}
+
+// InterestedTypeNotIn applies the NotIn predicate on the "interested_type" field.
+func InterestedTypeNotIn(vs ...string) predicate.Student {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Student(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldInterestedType), v...))
+	})
+}
+
+// InterestedTypeGT applies the GT predicate on the "interested_type" field.
+func InterestedTypeGT(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeGTE applies the GTE predicate on the "interested_type" field.
+func InterestedTypeGTE(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeLT applies the LT predicate on the "interested_type" field.
+func InterestedTypeLT(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeLTE applies the LTE predicate on the "interested_type" field.
+func InterestedTypeLTE(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeContains applies the Contains predicate on the "interested_type" field.
+func InterestedTypeContains(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeHasPrefix applies the HasPrefix predicate on the "interested_type" field.
+func InterestedTypeHasPrefix(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeHasSuffix applies the HasSuffix predicate on the "interested_type" field.
+func InterestedTypeHasSuffix(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeIsNil applies the IsNil predicate on the "interested_type" field.
+func InterestedTypeIsNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldInterestedType)))
+	})
+}
+
+// InterestedTypeNotNil applies the NotNil predicate on the "interested_type" field.
+func InterestedTypeNotNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldInterestedType)))
+	})
+}
+
+// InterestedTypeEqualFold applies the EqualFold predicate on the "interested_type" field.
+func InterestedTypeEqualFold(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldInterestedType), v))
+	})
+}
+
+// InterestedTypeContainsFold applies the ContainsFold predicate on the "interested_type" field.
+func InterestedTypeContainsFold(v string) predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldInterestedType), v))
+	})
+}
+
 // ProfileLinkEQ applies the EQ predicate on the "profile_link" field.
 func ProfileLinkEQ(v string) predicate.Student {
 	return predicate.Student(func(s *sql.Selector) {
@@ -435,6 +567,20 @@ func ProfileLinkHasPrefix(v string) predicate.Student {
 func ProfileLinkHasSuffix(v string) predicate.Student {
 	return predicate.Student(func(s *sql.Selector) {
 		s.Where(sql.HasSuffix(s.C(FieldProfileLink), v))
+	})
+}
+
+// ProfileLinkIsNil applies the IsNil predicate on the "profile_link" field.
+func ProfileLinkIsNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldProfileLink)))
+	})
+}
+
+// ProfileLinkNotNil applies the NotNil predicate on the "profile_link" field.
+func ProfileLinkNotNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldProfileLink)))
 	})
 }
 
@@ -546,6 +692,20 @@ func ProfileImageHasPrefix(v string) predicate.Student {
 func ProfileImageHasSuffix(v string) predicate.Student {
 	return predicate.Student(func(s *sql.Selector) {
 		s.Where(sql.HasSuffix(s.C(FieldProfileImage), v))
+	})
+}
+
+// ProfileImageIsNil applies the IsNil predicate on the "profile_image" field.
+func ProfileImageIsNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldProfileImage)))
+	})
+}
+
+// ProfileImageNotNil applies the NotNil predicate on the "profile_image" field.
+func ProfileImageNotNil() predicate.Student {
+	return predicate.Student(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldProfileImage)))
 	})
 }
 

--- a/api/ent/student_create.go
+++ b/api/ent/student_create.go
@@ -32,15 +32,51 @@ func (sc *StudentCreate) SetUniversity(s string) *StudentCreate {
 	return sc
 }
 
+// SetInterestedType sets the "interested_type" field.
+func (sc *StudentCreate) SetInterestedType(s string) *StudentCreate {
+	sc.mutation.SetInterestedType(s)
+	return sc
+}
+
+// SetNillableInterestedType sets the "interested_type" field if the given value is not nil.
+func (sc *StudentCreate) SetNillableInterestedType(s *string) *StudentCreate {
+	if s != nil {
+		sc.SetInterestedType(*s)
+	}
+	return sc
+}
+
 // SetProfileLink sets the "profile_link" field.
 func (sc *StudentCreate) SetProfileLink(s string) *StudentCreate {
 	sc.mutation.SetProfileLink(s)
 	return sc
 }
 
+// SetNillableProfileLink sets the "profile_link" field if the given value is not nil.
+func (sc *StudentCreate) SetNillableProfileLink(s *string) *StudentCreate {
+	if s != nil {
+		sc.SetProfileLink(*s)
+	}
+	return sc
+}
+
 // SetProfileImage sets the "profile_image" field.
 func (sc *StudentCreate) SetProfileImage(s string) *StudentCreate {
 	sc.mutation.SetProfileImage(s)
+	return sc
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (sc *StudentCreate) SetNillableProfileImage(s *string) *StudentCreate {
+	if s != nil {
+		sc.SetProfileImage(*s)
+	}
+	return sc
+}
+
+// SetID sets the "id" field.
+func (sc *StudentCreate) SetID(i int) *StudentCreate {
+	sc.mutation.SetID(i)
 	return sc
 }
 
@@ -131,12 +167,6 @@ func (sc *StudentCreate) check() error {
 	if _, ok := sc.mutation.University(); !ok {
 		return &ValidationError{Name: "university", err: errors.New(`ent: missing required field "university"`)}
 	}
-	if _, ok := sc.mutation.ProfileLink(); !ok {
-		return &ValidationError{Name: "profile_link", err: errors.New(`ent: missing required field "profile_link"`)}
-	}
-	if _, ok := sc.mutation.ProfileImage(); !ok {
-		return &ValidationError{Name: "profile_image", err: errors.New(`ent: missing required field "profile_image"`)}
-	}
 	if _, ok := sc.mutation.UserID(); !ok {
 		return &ValidationError{Name: "user", err: errors.New("ent: missing required edge \"user\"")}
 	}
@@ -151,8 +181,10 @@ func (sc *StudentCreate) sqlSave(ctx context.Context) (*Student, error) {
 		}
 		return nil, err
 	}
-	id := _spec.ID.Value.(int64)
-	_node.ID = int(id)
+	if _spec.ID.Value != _node.ID {
+		id := _spec.ID.Value.(int64)
+		_node.ID = int(id)
+	}
 	return _node, nil
 }
 
@@ -167,6 +199,10 @@ func (sc *StudentCreate) createSpec() (*Student, *sqlgraph.CreateSpec) {
 			},
 		}
 	)
+	if id, ok := sc.mutation.ID(); ok {
+		_node.ID = id
+		_spec.ID.Value = id
+	}
 	if value, ok := sc.mutation.Name(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -183,13 +219,21 @@ func (sc *StudentCreate) createSpec() (*Student, *sqlgraph.CreateSpec) {
 		})
 		_node.University = value
 	}
+	if value, ok := sc.mutation.InterestedType(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: student.FieldInterestedType,
+		})
+		_node.InterestedType = &value
+	}
 	if value, ok := sc.mutation.ProfileLink(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  value,
 			Column: student.FieldProfileLink,
 		})
-		_node.ProfileLink = value
+		_node.ProfileLink = &value
 	}
 	if value, ok := sc.mutation.ProfileImage(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
@@ -197,7 +241,7 @@ func (sc *StudentCreate) createSpec() (*Student, *sqlgraph.CreateSpec) {
 			Value:  value,
 			Column: student.FieldProfileImage,
 		})
-		_node.ProfileImage = value
+		_node.ProfileImage = &value
 	}
 	if nodes := sc.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -263,7 +307,7 @@ func (scb *StudentCreateBulk) Save(ctx context.Context) ([]*Student, error) {
 				}
 				mutation.id = &nodes[i].ID
 				mutation.done = true
-				if specs[i].ID.Value != nil {
+				if specs[i].ID.Value != nil && nodes[i].ID == 0 {
 					id := specs[i].ID.Value.(int64)
 					nodes[i].ID = int(id)
 				}

--- a/api/ent/student_update.go
+++ b/api/ent/student_update.go
@@ -40,15 +40,63 @@ func (su *StudentUpdate) SetUniversity(s string) *StudentUpdate {
 	return su
 }
 
+// SetInterestedType sets the "interested_type" field.
+func (su *StudentUpdate) SetInterestedType(s string) *StudentUpdate {
+	su.mutation.SetInterestedType(s)
+	return su
+}
+
+// SetNillableInterestedType sets the "interested_type" field if the given value is not nil.
+func (su *StudentUpdate) SetNillableInterestedType(s *string) *StudentUpdate {
+	if s != nil {
+		su.SetInterestedType(*s)
+	}
+	return su
+}
+
+// ClearInterestedType clears the value of the "interested_type" field.
+func (su *StudentUpdate) ClearInterestedType() *StudentUpdate {
+	su.mutation.ClearInterestedType()
+	return su
+}
+
 // SetProfileLink sets the "profile_link" field.
 func (su *StudentUpdate) SetProfileLink(s string) *StudentUpdate {
 	su.mutation.SetProfileLink(s)
 	return su
 }
 
+// SetNillableProfileLink sets the "profile_link" field if the given value is not nil.
+func (su *StudentUpdate) SetNillableProfileLink(s *string) *StudentUpdate {
+	if s != nil {
+		su.SetProfileLink(*s)
+	}
+	return su
+}
+
+// ClearProfileLink clears the value of the "profile_link" field.
+func (su *StudentUpdate) ClearProfileLink() *StudentUpdate {
+	su.mutation.ClearProfileLink()
+	return su
+}
+
 // SetProfileImage sets the "profile_image" field.
 func (su *StudentUpdate) SetProfileImage(s string) *StudentUpdate {
 	su.mutation.SetProfileImage(s)
+	return su
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (su *StudentUpdate) SetNillableProfileImage(s *string) *StudentUpdate {
+	if s != nil {
+		su.SetProfileImage(*s)
+	}
+	return su
+}
+
+// ClearProfileImage clears the value of the "profile_image" field.
+func (su *StudentUpdate) ClearProfileImage() *StudentUpdate {
+	su.mutation.ClearProfileImage()
 	return su
 }
 
@@ -174,6 +222,19 @@ func (su *StudentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: student.FieldUniversity,
 		})
 	}
+	if value, ok := su.mutation.InterestedType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: student.FieldInterestedType,
+		})
+	}
+	if su.mutation.InterestedTypeCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: student.FieldInterestedType,
+		})
+	}
 	if value, ok := su.mutation.ProfileLink(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -181,10 +242,22 @@ func (su *StudentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: student.FieldProfileLink,
 		})
 	}
+	if su.mutation.ProfileLinkCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: student.FieldProfileLink,
+		})
+	}
 	if value, ok := su.mutation.ProfileImage(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  value,
+			Column: student.FieldProfileImage,
+		})
+	}
+	if su.mutation.ProfileImageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
 			Column: student.FieldProfileImage,
 		})
 	}
@@ -254,15 +327,63 @@ func (suo *StudentUpdateOne) SetUniversity(s string) *StudentUpdateOne {
 	return suo
 }
 
+// SetInterestedType sets the "interested_type" field.
+func (suo *StudentUpdateOne) SetInterestedType(s string) *StudentUpdateOne {
+	suo.mutation.SetInterestedType(s)
+	return suo
+}
+
+// SetNillableInterestedType sets the "interested_type" field if the given value is not nil.
+func (suo *StudentUpdateOne) SetNillableInterestedType(s *string) *StudentUpdateOne {
+	if s != nil {
+		suo.SetInterestedType(*s)
+	}
+	return suo
+}
+
+// ClearInterestedType clears the value of the "interested_type" field.
+func (suo *StudentUpdateOne) ClearInterestedType() *StudentUpdateOne {
+	suo.mutation.ClearInterestedType()
+	return suo
+}
+
 // SetProfileLink sets the "profile_link" field.
 func (suo *StudentUpdateOne) SetProfileLink(s string) *StudentUpdateOne {
 	suo.mutation.SetProfileLink(s)
 	return suo
 }
 
+// SetNillableProfileLink sets the "profile_link" field if the given value is not nil.
+func (suo *StudentUpdateOne) SetNillableProfileLink(s *string) *StudentUpdateOne {
+	if s != nil {
+		suo.SetProfileLink(*s)
+	}
+	return suo
+}
+
+// ClearProfileLink clears the value of the "profile_link" field.
+func (suo *StudentUpdateOne) ClearProfileLink() *StudentUpdateOne {
+	suo.mutation.ClearProfileLink()
+	return suo
+}
+
 // SetProfileImage sets the "profile_image" field.
 func (suo *StudentUpdateOne) SetProfileImage(s string) *StudentUpdateOne {
 	suo.mutation.SetProfileImage(s)
+	return suo
+}
+
+// SetNillableProfileImage sets the "profile_image" field if the given value is not nil.
+func (suo *StudentUpdateOne) SetNillableProfileImage(s *string) *StudentUpdateOne {
+	if s != nil {
+		suo.SetProfileImage(*s)
+	}
+	return suo
+}
+
+// ClearProfileImage clears the value of the "profile_image" field.
+func (suo *StudentUpdateOne) ClearProfileImage() *StudentUpdateOne {
+	suo.mutation.ClearProfileImage()
 	return suo
 }
 
@@ -412,6 +533,19 @@ func (suo *StudentUpdateOne) sqlSave(ctx context.Context) (_node *Student, err e
 			Column: student.FieldUniversity,
 		})
 	}
+	if value, ok := suo.mutation.InterestedType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: student.FieldInterestedType,
+		})
+	}
+	if suo.mutation.InterestedTypeCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: student.FieldInterestedType,
+		})
+	}
 	if value, ok := suo.mutation.ProfileLink(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
@@ -419,10 +553,22 @@ func (suo *StudentUpdateOne) sqlSave(ctx context.Context) (_node *Student, err e
 			Column: student.FieldProfileLink,
 		})
 	}
+	if suo.mutation.ProfileLinkCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: student.FieldProfileLink,
+		})
+	}
 	if value, ok := suo.mutation.ProfileImage(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  value,
+			Column: student.FieldProfileImage,
+		})
+	}
+	if suo.mutation.ProfileImageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
 			Column: student.FieldProfileImage,
 		})
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -14,9 +14,14 @@ func main() {
 	dbClient := repository.Connect()
 
 	userRepo := repository.NewUserRepository(dbClient)
-	userService := service.NewUserSerivce(userRepo)
-	userHandler := handler.NewUserHandler(userService)
+	studentRepo := repository.NewStudentRepository(dbClient)
 
-	server := http.NewServer(userHandler)
+	userService := service.NewUserSerivce(userRepo, studentRepo)
+	studentService := service.NewStudentService(studentRepo)
+
+	userHandler := handler.NewUserHandler(userService, studentService)
+	studentHandler := handler.NewStudentHandler(studentService)
+
+	server := http.NewServer(userHandler, studentHandler)
 	server.Logger.Fatal(server.Start(fmt.Sprintf(":%d", config.Config.Port)))
 }

--- a/api/repository/student.go
+++ b/api/repository/student.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/Wanted-Linx/linx-backend/api/domain"
+	"github.com/Wanted-Linx/linx-backend/api/ent"
+	"github.com/Wanted-Linx/linx-backend/api/ent/student"
+	"github.com/pkg/errors"
+)
+
+type studentRepository struct {
+	db *ent.Client
+}
+
+func NewStudentRepository(db *ent.Client) domain.StudentRepository {
+	return &studentRepository{db: db}
+}
+
+func (r *studentRepository) Save(reqStudent *ent.Student) (*ent.Student, error) {
+	s, err := r.db.Student.Create().
+		SetID(reqStudent.ID).
+		SetName(reqStudent.Name).
+		SetUniversity(reqStudent.University).
+		SetUser(reqStudent.Edges.User).
+		SetNillableProfileLink(reqStudent.ProfileLink).
+		SetNillableProfileImage(reqStudent.ProfileImage).
+		SetNillableInterestedType(reqStudent.InterestedType).
+		Save(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := s.QueryUser().First(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	s.Edges.User = user
+	return s, nil
+}
+
+func (r *studentRepository) GetByID(studentID int, reqStudent *ent.Student) (*ent.Student, error) {
+	s, err := r.db.Student.Query().
+		Where(student.ID(studentID)).
+		Only(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/api/service/student.go
+++ b/api/service/student.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"github.com/Wanted-Linx/linx-backend/api/domain"
+	"github.com/Wanted-Linx/linx-backend/api/ent"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type studentService struct {
+	studentRepo domain.StudentRepository
+}
+
+func NewStudentService(studentRepo domain.StudentRepository) domain.StudentService {
+	return &studentService{studentRepo: studentRepo}
+}
+
+func (s *studentService) Save(userID int, reqSignup *domain.SignUpRequest) (*domain.StudentDto, error) {
+	student := &ent.Student{
+		ID:         userID,
+		Name:       reqSignup.Name,
+		University: reqSignup.University,
+		Edges: ent.StudentEdges{
+			User: &ent.User{ID: userID},
+		},
+	}
+
+	newStudent, err := s.studentRepo.Save(student)
+	if err != nil {
+		return nil, errors.WithMessage(err, "알 수 없는 에러가 발생했습니다.")
+	}
+
+	log.Info("회원가입(학생) 완료", newStudent)
+	return domain.StudentToDto(newStudent), nil
+}
+
+func (s *studentService) GetStudentByID(studentID int) (*domain.StudentDto, error) {
+
+	return nil, nil
+}

--- a/api/service/user.go
+++ b/api/service/user.go
@@ -13,11 +13,15 @@ import (
 )
 
 type userService struct {
-	userRepo domain.UserReposiory
+	userRepo    domain.UserReposiory
+	studentRepo domain.StudentRepository
 }
 
-func NewUserSerivce(userRepo domain.UserReposiory) domain.UserService {
-	return &userService{userRepo: userRepo}
+func NewUserSerivce(userRepo domain.UserReposiory, studentRepo domain.StudentRepository) domain.UserService {
+	return &userService{
+		userRepo:    userRepo,
+		studentRepo: studentRepo,
+	}
 }
 
 func (s *userService) SignUp(reqSignUp *domain.SignUpRequest) (*domain.UserDto, error) {
@@ -26,6 +30,7 @@ func (s *userService) SignUp(reqSignUp *domain.SignUpRequest) (*domain.UserDto, 
 		return nil, errors.WithMessage(err, "알 수 없는 오류가 발생했습니다.")
 	}
 
+	log.Println(reqSignUp)
 	u := &ent.User{
 		Email:    reqSignUp.Email,
 		Password: hashPassword,
@@ -40,13 +45,28 @@ func (s *userService) SignUp(reqSignUp *domain.SignUpRequest) (*domain.UserDto, 
 		return nil, errors.WithMessage(err, "알 수 없는 에러가 발생했습니다.")
 	}
 
-	if newUser.Kind.String() == "student" {
-		// register student table
-		log.Info("회원가입(학생) 성공")
-	} else {
-		// register company table
-		log.Info("회원가입(기업) 성공")
-	}
+	// if newUser.Kind.String() == "student" {
+	// 	// register student table
+	// 	student := &ent.Student{
+	// 		ID:         newUser.ID,
+	// 		Name:       reqSignUp.Name,
+	// 		University: reqSignUp.University,
+	// 		Edges: ent.StudentEdges{
+	// 			User: &ent.User{ID: newUser.ID},
+	// 		},
+	// 	}
+
+	// 	newStudent, err := s.studentRepo.Save(student)
+	// 	if err != nil {
+	// 		log.Info("회원가입(학생) 실패")
+	// 		return nil, errors.WithMessage(err, "알 수 없는 에러가 발생했습니다.")
+	// 	}
+
+	// 	log.Info("회원가입(학생) 성공", newStudent)
+	// } else {
+	// 	// register company table
+	// 	log.Info("회원가입(기업) 성공")
+	// }
 
 	return domain.UserToDto(newUser), nil
 }

--- a/api/util/request.go
+++ b/api/util/request.go
@@ -1,1 +1,13 @@
 package util
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+func GetRequestUserID(c echo.Context) (int, error) {
+	header := c.Request().Header
+
+	return strconv.Atoi(header["User"][0])
+}


### PR DESCRIPTION
**PR  요약**
- Student의 id(PK, FK) 값을 User의 id 값으로 설정
- 회원가입 요청 왔을 때 학생 계정 생성하도록 구현