### PR TITLE
동아리 목록, 상세 조회(동아리 멤버들도 리턴)

### DIFF
--- a/api/delivery/http/handler/club_handler.go
+++ b/api/delivery/http/handler/club_handler.go
@@ -1,10 +1,13 @@
 package handler
 
 import (
+	"strconv"
+
 	"github.com/Wanted-Linx/linx-backend/api/domain"
 	"github.com/Wanted-Linx/linx-backend/api/util"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type ClubHandler struct {
@@ -32,4 +35,49 @@ func (h *ClubHandler) CreateClub(c echo.Context) error {
 	}
 
 	return c.JSON(200, newClub)
+}
+
+func (h *ClubHandler) GetClubByID(c echo.Context) error {
+	userID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	log.Info("조회 요청한 유저 id:", userID)
+	clubID, err := strconv.Atoi(util.GetParams("club_id", c))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	club, err := h.clubService.GetClubByID(clubID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, club)
+}
+
+func (h *ClubHandler) GetAllClubs(c echo.Context) error {
+	userID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	log.Info("조회 요청한 유저 id:", userID)
+	limit, err := strconv.Atoi(util.GetQueryParams("limit", c))
+	if err != nil {
+		return errors.WithMessage(err, "잘못된 query string으로 입력했습니다.")
+	}
+
+	offset, err := strconv.Atoi(util.GetQueryParams("offset", c))
+	if err != nil {
+		return errors.WithMessage(err, "잘못된 query string으로 입력했습니다.")
+	}
+
+	clubs, err := h.clubService.GetAllClubs(limit, offset)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, clubs)
 }

--- a/api/delivery/http/handler/student_handler.go
+++ b/api/delivery/http/handler/student_handler.go
@@ -26,7 +26,7 @@ func (h *StudentHandler) GetStudent(c echo.Context) error {
 		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
 	}
 
-	log.Info("조회하는 유저", studentID)
+	log.Info("조회 요청 유저 id: ", studentID)
 
 	ownerID, err := strconv.Atoi(util.GetQueryParams("owner", c))
 	if err != nil {

--- a/api/delivery/http/router.go
+++ b/api/delivery/http/router.go
@@ -25,8 +25,10 @@ func userRouter(userHandler *handler.UserHandler) {
 func studentRouter(studentHandler *handler.StudentHandler) {
 	group := e.Group("/students")
 	group.GET("", studentHandler.GetStudent)
-	group.PUT("/profile", studentHandler.UpdateProfile)
+	// 학생 프로필 업로드
 	group.POST("/profile/images", studentHandler.UploadProfileImage)
+	// 학생 프로필 수정
+	group.PUT("/profile", studentHandler.UpdateProfile)
 	group.GET("/profile/images", studentHandler.GetProfileImage)
 }
 
@@ -37,9 +39,12 @@ func companyRouter(companyHandler *handler.CompanyHandler) {
 func clubRouter(clubHandler *handler.ClubHandler) {
 	group := e.Group("/clubs")
 	group.POST("", clubHandler.CreateClub)
+	group.GET("", clubHandler.GetAllClubs)
+	group.GET("/:club_id", clubHandler.GetClubByID)
 }
 
 func clubMemberRouter(clubMemberHandler *handler.ClubMemberHandler) {
+	// 동아리에 가입 API
 	group := e.Group("/clubs/members")
 	group.POST("", clubMemberHandler.RegisterClubMember)
 }

--- a/api/domain/club.go
+++ b/api/domain/club.go
@@ -9,6 +9,7 @@ import (
 type ClubDto struct {
 	ID             int           `json:"id"`
 	LeaderID       int           `json:"leader_id"`
+	LeaderName     string        `json:"leader_name"`
 	Name           string        `json:"name"`
 	Organization   string        `json:"organization"`
 	Description    string        `json:"description"`
@@ -30,12 +31,13 @@ type ClubCreateRequest struct {
 type ClubService interface {
 	CreateClub(studentID int, reqClub *ClubCreateRequest) (*ClubDto, error)
 	GetClubByID(clubID int) (*ClubDto, error)
+	GetAllClubs(limit, offset int) ([]*ClubDto, error)
 }
 
 type ClubRepository interface {
 	Save(reqClub *ent.Club) (*ent.Club, error)
-	GetByID(clubID int) (*ent.Club, error)
-	// GetAll(clubID int) ([]*ent.Student, error)
+	GetByID(clubID int) (*ent.Club, []*ent.Student, error)
+	GetAll(limit, offset int) ([]*ent.Club, [][]*ent.Student, error)
 }
 
 func ClubToDto(srcClub *ent.Club, srcClubMembers []*ent.Student) *ClubDto {
@@ -44,6 +46,7 @@ func ClubToDto(srcClub *ent.Club, srcClubMembers []*ent.Student) *ClubDto {
 	return &ClubDto{
 		ID:           srcClub.ID,
 		LeaderID:     srcClub.Edges.Leader.ID,
+		LeaderName:   srcClub.Edges.Leader.Name,
 		Name:         srcClub.Name,
 		Organization: srcClub.Organization,
 		Description:  srcClub.Description,

--- a/api/domain/club_member.go
+++ b/api/domain/club_member.go
@@ -13,6 +13,7 @@ type ClubMember struct {
 
 type JoinedClub struct {
 	ClubID       int    `json:"club_id"`
+	LeaderID     int    `json:"leader_id"`
 	LeaderName   string `json:"leader_name"`
 	Name         string `json:"name"`
 	Organization string `json:"organization"`
@@ -48,6 +49,7 @@ func MemberClubsToDto(srcMemberClubs []*ent.Club) []*JoinedClub {
 	for _, memberClub := range srcMemberClubs {
 		var club JoinedClub
 		club.ClubID = memberClub.ID
+		club.LeaderID = memberClub.Edges.Leader.ID
 		club.LeaderName = memberClub.Edges.Leader.Name
 		club.Name = memberClub.Name
 		club.Organization = memberClub.Organization

--- a/api/service/club.go
+++ b/api/service/club.go
@@ -59,6 +59,30 @@ func (s *clubService) CreateClub(clubLeaderID int, reqClub *domain.ClubCreateReq
 }
 
 func (s *clubService) GetClubByID(clubID int) (*domain.ClubDto, error) {
+	club, members, err := s.clubRepo.GetByID(clubID)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, errors.WithMessage(err, "해당하는 동아리를 찾지 못했습니다.")
+		}
+		return nil, errors.WithMessage(err, "알 수 없는 오류가 발생했습니다.")
+	}
 
-	return nil, nil
+	log.Info("동아리 조회 완료", club, members)
+	return domain.ClubToDto(club, members), nil
+}
+
+func (s *clubService) GetAllClubs(limit, offset int) ([]*domain.ClubDto, error) {
+	clubs, allMembers, err := s.clubRepo.GetAll(limit, offset)
+	if err != nil {
+		return nil, errors.WithMessage(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	clubsDto := make([]*domain.ClubDto, len(clubs))
+
+	for idx, club := range clubs {
+		clubDto := domain.ClubToDto(club, allMembers[idx])
+		clubsDto[idx] = clubDto
+	}
+
+	return clubsDto, nil
 }

--- a/api/util/request.go
+++ b/api/util/request.go
@@ -15,3 +15,7 @@ func GetRequestUserID(c echo.Context) (int, error) {
 func GetQueryParams(param string, c echo.Context) string {
 	return c.QueryParam(param)
 }
+
+func GetParams(param string, c echo.Context) string {
+	return c.Param(param)
+}


### PR DESCRIPTION
**PR요약**
- 동아리 조회 API 작성
- 동아리 목록 조회할 때는 `limit` ,`offset` 으로 pagiantion
- club entity 와 student entity 가edge 관계가 아니라서 각 club query하고 `club.QueryClubMember().QueryStudent().All` 을 각 동아리 마다 계속 반복해서 구현(좋지 않은 구현... 추후에 수정하자)