### PR TITLE
기업 프로필 및 조회 API 구현

### DIFF
--- a/api/delivery/http/handler/company_handler.go
+++ b/api/delivery/http/handler/company_handler.go
@@ -1,6 +1,15 @@
 package handler
 
-import "github.com/Wanted-Linx/linx-backend/api/domain"
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Wanted-Linx/linx-backend/api/domain"
+	"github.com/Wanted-Linx/linx-backend/api/util"
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
 
 type CompanyHandler struct {
 	companySerivce domain.CompanyService
@@ -8,4 +17,112 @@ type CompanyHandler struct {
 
 func NewCompanyHandler(companySerivce domain.CompanyService) *CompanyHandler {
 	return &CompanyHandler{companySerivce: companySerivce}
+}
+
+func (h *CompanyHandler) GetCompany(c echo.Context) error {
+	// 인증용 id
+	userID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	log.Info("조회 요청 유저 id: ", userID)
+
+	ownerID, err := strconv.Atoi(util.GetQueryParams("owner", c))
+	if err != nil {
+		return errors.Wrap(err, "잘못된 query string을 입력했습니다.")
+	}
+
+	s, err := h.companySerivce.GetCompanyByID(ownerID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, s)
+}
+
+func (h *CompanyHandler) GetAllCompanies(c echo.Context) error {
+	userID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	log.Info("조회 요청 유저 id: ", userID)
+
+	limit, err := strconv.Atoi(util.GetQueryParams("limit", c))
+	if err != nil {
+		return errors.WithMessage(err, "잘못된 query string으로 입력했습니다.")
+	}
+
+	offset, err := strconv.Atoi(util.GetQueryParams("offset", c))
+	if err != nil {
+		return errors.WithMessage(err, "잘못된 query string으로 입력했습니다.")
+	}
+
+	companies, err := h.companySerivce.GetAllCompanies(limit, offset)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, companies)
+}
+
+func (h *CompanyHandler) UpdateProfile(c echo.Context) error {
+	companyID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	reqUpdate := new(domain.CompanyProfileUpdate)
+	if err := c.Bind(&reqUpdate); err != nil {
+		return errors.Wrap(err, "잘못된 json body 입니다.")
+	}
+
+	company, err := h.companySerivce.UpdateProfile(companyID, reqUpdate)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, company)
+}
+
+func (h *CompanyHandler) UploadProfileImage(c echo.Context) error {
+	companyID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	form, err := c.MultipartForm()
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	reqImage := &domain.CompanyProfileImage{
+		Image: form.File["image"],
+	}
+
+	if err := c.Bind(&reqImage); err != nil {
+		return errors.Wrap(err, "잘못된 json body 입니다.")
+	}
+
+	fileBytes, err := h.companySerivce.UploadProfileImage(companyID, reqImage)
+	if err != nil {
+		return err
+	}
+
+	return c.Blob(200, http.DetectContentType(fileBytes), fileBytes)
+}
+
+func (h *CompanyHandler) GetProfileImage(c echo.Context) error {
+	companyID, err := util.GetRequestUserID(c)
+	if err != nil {
+		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	fileBytes, err := h.companySerivce.GetProfileImage(companyID)
+	if err != nil {
+		return err
+	}
+
+	return c.Blob(200, http.DetectContentType(fileBytes), fileBytes)
 }

--- a/api/delivery/http/handler/student_handler.go
+++ b/api/delivery/http/handler/student_handler.go
@@ -21,12 +21,12 @@ func NewStudentHandler(studentService domain.StudentService) *StudentHandler {
 
 func (h *StudentHandler) GetStudent(c echo.Context) error {
 	// 인증용 id
-	studentID, err := util.GetRequestUserID(c)
+	userID, err := util.GetRequestUserID(c)
 	if err != nil {
 		return errors.Wrap(err, "알 수 없는 오류가 발생했습니다.")
 	}
 
-	log.Info("조회 요청 유저 id: ", studentID)
+	log.Info("조회 요청 유저 id: ", userID)
 
 	ownerID, err := strconv.Atoi(util.GetQueryParams("owner", c))
 	if err != nil {

--- a/api/delivery/http/router.go
+++ b/api/delivery/http/router.go
@@ -24,6 +24,7 @@ func userRouter(userHandler *handler.UserHandler) {
 
 func studentRouter(studentHandler *handler.StudentHandler) {
 	group := e.Group("/students")
+	// ?owner={{student_id}}
 	group.GET("", studentHandler.GetStudent)
 	// 학생 프로필 업로드
 	group.POST("/profile/images", studentHandler.UploadProfileImage)
@@ -33,7 +34,15 @@ func studentRouter(studentHandler *handler.StudentHandler) {
 }
 
 func companyRouter(companyHandler *handler.CompanyHandler) {
-	_ = e.Group("/companies")
+	group := e.Group("/companies")
+	// ?owner={{company_id}}
+	group.GET("", companyHandler.GetCompany)
+	group.GET("", companyHandler.GetAllCompanies)
+	// 기업 프로필 이미지 업로드
+	group.POST("/profile/images", companyHandler.UploadProfileImage)
+	// 기업 프로필 수정
+	group.PUT("/profile", companyHandler.UpdateProfile)
+	group.GET("/profile/images", companyHandler.GetProfileImage)
 }
 
 func clubRouter(clubHandler *handler.ClubHandler) {

--- a/api/domain/company.go
+++ b/api/domain/company.go
@@ -1,23 +1,51 @@
 package domain
 
-import "github.com/Wanted-Linx/linx-backend/api/ent"
+import (
+	"mime/multipart"
+
+	"github.com/Wanted-Linx/linx-backend/api/ent"
+)
 
 type CompanyDto struct {
 	ID             int      `json:"id"`
 	Name           string   `json:"name"`
 	BusinessType   []string `json:"business_type"`
 	Description    *string  `json:"description"`
-	BusinessNumber *string  `json:"business_number"`
+	BusinessNumber string   `json:"business_number"`
 	ProfileImage   *string  `json:"profile_image"`
+	Homepage       *string  `json:"hompage"`
+}
+
+type CompanyProfileImageDto struct {
+	Image []byte `json:"image"`
+}
+
+// Multipart form-data로 이미지랑 같이 받을까...?
+type CompanyProfileUpdate struct {
+	BusinessType []string `json:"business_type"`
+	Homepage     string   `json:"homepage"`
+	Description  string   `json:"description"`
+}
+
+type CompanyProfileImage struct {
+	Image []*multipart.FileHeader `json:"image"`
 }
 
 type CompanyService interface {
 	Save(userID int, reqSignup *SignUpRequest) (*CompanyDto, error)
 	GetCompanyByID(companyID int) (*CompanyDto, error)
+	GetAllCompanies(limit, offset int) ([]*CompanyDto, error)
+	UpdateProfile(companyID int, reqCompany *CompanyProfileUpdate) (*CompanyDto, error)
+	UploadProfileImage(companyID int, reqImage *CompanyProfileImage) ([]byte, error)
+	GetProfileImage(companyID int) ([]byte, error)
 }
+
 type CompanyRepository interface {
 	Save(reqStudent *ent.Company) (*ent.Company, error)
 	GetByID(studentID int, reqStudent *ent.Company) (*ent.Company, error)
+	GetAll(limit, offset int) ([]*ent.Company, error)
+	UpdateProfile(reqCompany *ent.Company) (*ent.Company, error)
+	UploadProfileImage(reqCompany *ent.Company) (*ent.Company, error)
 	// GetAll(clubID int) ([]*ent.Student, error)
 }
 
@@ -25,9 +53,21 @@ func CompanyToDto(src *ent.Company) *CompanyDto {
 	return &CompanyDto{
 		ID:             src.Edges.User.ID,
 		Name:           src.Name,
-		BusinessNumber: &src.BusinessNumber,
+		BusinessNumber: src.BusinessNumber,
 		Description:    src.Description,
 		ProfileImage:   src.ProfileImage,
-		// BusinessType:  ,
+		Homepage:       src.Hompage,
+		BusinessType:   []string{"개발", "디자인"}, // TODO: default로 이렇게 잡아뒀지만 추후 businesstype 테이블 생성 후 그에 맞게 수정...
 	}
+}
+
+func CompaniesToDto(src []*ent.Company) []*CompanyDto {
+	companiesDto := make([]*CompanyDto, 0)
+
+	for _, company := range src {
+		companyDto := CompanyToDto(company)
+		companiesDto = append(companiesDto, companyDto)
+	}
+
+	return companiesDto
 }

--- a/api/domain/student.go
+++ b/api/domain/student.go
@@ -43,6 +43,7 @@ type StudentRepository interface {
 	GetByID(studentID int, reqStudent *ent.Student) (*ent.Student, error)
 	UpdateProfile(reqStudent *ent.Student) (*ent.Student, error)
 	UploadProfileImage(reqStudent *ent.Student) (*ent.Student, error)
+	// GetProfileImage(reqStudent *ent.Student) ([]byte, error)
 	// GetAll(clubID int) ([]*ent.Student, error)
 }
 

--- a/api/ent/company.go
+++ b/api/ent/company.go
@@ -26,6 +26,8 @@ type Company struct {
 	Description *string `json:"description,omitempty"`
 	// ProfileImage holds the value of the "profile_image" field.
 	ProfileImage *string `json:"profile_image,omitempty"`
+	// Hompage holds the value of the "hompage" field.
+	Hompage *string `json:"hompage,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CompanyQuery when eager-loading is set.
 	Edges        CompanyEdges `json:"edges"`
@@ -62,7 +64,7 @@ func (*Company) scanValues(columns []string) ([]interface{}, error) {
 		switch columns[i] {
 		case company.FieldID:
 			values[i] = new(sql.NullInt64)
-		case company.FieldName, company.FieldBusinessNumber, company.FieldAddress, company.FieldDescription, company.FieldProfileImage:
+		case company.FieldName, company.FieldBusinessNumber, company.FieldAddress, company.FieldDescription, company.FieldProfileImage, company.FieldHompage:
 			values[i] = new(sql.NullString)
 		case company.ForeignKeys[0]: // user_company
 			values[i] = new(sql.NullInt64)
@@ -120,6 +122,13 @@ func (c *Company) assignValues(columns []string, values []interface{}) error {
 				c.ProfileImage = new(string)
 				*c.ProfileImage = value.String
 			}
+		case company.FieldHompage:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field hompage", values[i])
+			} else if value.Valid {
+				c.Hompage = new(string)
+				*c.Hompage = value.String
+			}
 		case company.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for edge-field user_company", value)
@@ -174,6 +183,10 @@ func (c *Company) String() string {
 	}
 	if v := c.ProfileImage; v != nil {
 		builder.WriteString(", profile_image=")
+		builder.WriteString(*v)
+	}
+	if v := c.Hompage; v != nil {
+		builder.WriteString(", hompage=")
 		builder.WriteString(*v)
 	}
 	builder.WriteByte(')')

--- a/api/ent/company/company.go
+++ b/api/ent/company/company.go
@@ -17,6 +17,8 @@ const (
 	FieldDescription = "description"
 	// FieldProfileImage holds the string denoting the profile_image field in the database.
 	FieldProfileImage = "profile_image"
+	// FieldHompage holds the string denoting the hompage field in the database.
+	FieldHompage = "hompage"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// Table holds the table name of the company in the database.
@@ -38,6 +40,7 @@ var Columns = []string{
 	FieldAddress,
 	FieldDescription,
 	FieldProfileImage,
+	FieldHompage,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "companies"

--- a/api/ent/company/where.go
+++ b/api/ent/company/where.go
@@ -126,6 +126,13 @@ func ProfileImage(v string) predicate.Company {
 	})
 }
 
+// Hompage applies equality check predicate on the "hompage" field. It's identical to HompageEQ.
+func Hompage(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldHompage), v))
+	})
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Company {
 	return predicate.Company(func(s *sql.Selector) {
@@ -720,6 +727,131 @@ func ProfileImageEqualFold(v string) predicate.Company {
 func ProfileImageContainsFold(v string) predicate.Company {
 	return predicate.Company(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldProfileImage), v))
+	})
+}
+
+// HompageEQ applies the EQ predicate on the "hompage" field.
+func HompageEQ(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldHompage), v))
+	})
+}
+
+// HompageNEQ applies the NEQ predicate on the "hompage" field.
+func HompageNEQ(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldHompage), v))
+	})
+}
+
+// HompageIn applies the In predicate on the "hompage" field.
+func HompageIn(vs ...string) predicate.Company {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Company(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldHompage), v...))
+	})
+}
+
+// HompageNotIn applies the NotIn predicate on the "hompage" field.
+func HompageNotIn(vs ...string) predicate.Company {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Company(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldHompage), v...))
+	})
+}
+
+// HompageGT applies the GT predicate on the "hompage" field.
+func HompageGT(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldHompage), v))
+	})
+}
+
+// HompageGTE applies the GTE predicate on the "hompage" field.
+func HompageGTE(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldHompage), v))
+	})
+}
+
+// HompageLT applies the LT predicate on the "hompage" field.
+func HompageLT(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldHompage), v))
+	})
+}
+
+// HompageLTE applies the LTE predicate on the "hompage" field.
+func HompageLTE(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldHompage), v))
+	})
+}
+
+// HompageContains applies the Contains predicate on the "hompage" field.
+func HompageContains(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldHompage), v))
+	})
+}
+
+// HompageHasPrefix applies the HasPrefix predicate on the "hompage" field.
+func HompageHasPrefix(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldHompage), v))
+	})
+}
+
+// HompageHasSuffix applies the HasSuffix predicate on the "hompage" field.
+func HompageHasSuffix(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldHompage), v))
+	})
+}
+
+// HompageIsNil applies the IsNil predicate on the "hompage" field.
+func HompageIsNil() predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldHompage)))
+	})
+}
+
+// HompageNotNil applies the NotNil predicate on the "hompage" field.
+func HompageNotNil() predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldHompage)))
+	})
+}
+
+// HompageEqualFold applies the EqualFold predicate on the "hompage" field.
+func HompageEqualFold(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldHompage), v))
+	})
+}
+
+// HompageContainsFold applies the ContainsFold predicate on the "hompage" field.
+func HompageContainsFold(v string) predicate.Company {
+	return predicate.Company(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldHompage), v))
 	})
 }
 

--- a/api/ent/company_create.go
+++ b/api/ent/company_create.go
@@ -74,6 +74,20 @@ func (cc *CompanyCreate) SetNillableProfileImage(s *string) *CompanyCreate {
 	return cc
 }
 
+// SetHompage sets the "hompage" field.
+func (cc *CompanyCreate) SetHompage(s string) *CompanyCreate {
+	cc.mutation.SetHompage(s)
+	return cc
+}
+
+// SetNillableHompage sets the "hompage" field if the given value is not nil.
+func (cc *CompanyCreate) SetNillableHompage(s *string) *CompanyCreate {
+	if s != nil {
+		cc.SetHompage(*s)
+	}
+	return cc
+}
+
 // SetID sets the "id" field.
 func (cc *CompanyCreate) SetID(i int) *CompanyCreate {
 	cc.mutation.SetID(i)
@@ -242,6 +256,14 @@ func (cc *CompanyCreate) createSpec() (*Company, *sqlgraph.CreateSpec) {
 			Column: company.FieldProfileImage,
 		})
 		_node.ProfileImage = &value
+	}
+	if value, ok := cc.mutation.Hompage(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: company.FieldHompage,
+		})
+		_node.Hompage = &value
 	}
 	if nodes := cc.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/api/ent/company_update.go
+++ b/api/ent/company_update.go
@@ -100,6 +100,26 @@ func (cu *CompanyUpdate) ClearProfileImage() *CompanyUpdate {
 	return cu
 }
 
+// SetHompage sets the "hompage" field.
+func (cu *CompanyUpdate) SetHompage(s string) *CompanyUpdate {
+	cu.mutation.SetHompage(s)
+	return cu
+}
+
+// SetNillableHompage sets the "hompage" field if the given value is not nil.
+func (cu *CompanyUpdate) SetNillableHompage(s *string) *CompanyUpdate {
+	if s != nil {
+		cu.SetHompage(*s)
+	}
+	return cu
+}
+
+// ClearHompage clears the value of the "hompage" field.
+func (cu *CompanyUpdate) ClearHompage() *CompanyUpdate {
+	cu.mutation.ClearHompage()
+	return cu
+}
+
 // SetUserID sets the "user" edge to the User entity by ID.
 func (cu *CompanyUpdate) SetUserID(id int) *CompanyUpdate {
 	cu.mutation.SetUserID(id)
@@ -261,6 +281,19 @@ func (cu *CompanyUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: company.FieldProfileImage,
 		})
 	}
+	if value, ok := cu.mutation.Hompage(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: company.FieldHompage,
+		})
+	}
+	if cu.mutation.HompageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: company.FieldHompage,
+		})
+	}
 	if cu.mutation.UserCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -384,6 +417,26 @@ func (cuo *CompanyUpdateOne) SetNillableProfileImage(s *string) *CompanyUpdateOn
 // ClearProfileImage clears the value of the "profile_image" field.
 func (cuo *CompanyUpdateOne) ClearProfileImage() *CompanyUpdateOne {
 	cuo.mutation.ClearProfileImage()
+	return cuo
+}
+
+// SetHompage sets the "hompage" field.
+func (cuo *CompanyUpdateOne) SetHompage(s string) *CompanyUpdateOne {
+	cuo.mutation.SetHompage(s)
+	return cuo
+}
+
+// SetNillableHompage sets the "hompage" field if the given value is not nil.
+func (cuo *CompanyUpdateOne) SetNillableHompage(s *string) *CompanyUpdateOne {
+	if s != nil {
+		cuo.SetHompage(*s)
+	}
+	return cuo
+}
+
+// ClearHompage clears the value of the "hompage" field.
+func (cuo *CompanyUpdateOne) ClearHompage() *CompanyUpdateOne {
+	cuo.mutation.ClearHompage()
 	return cuo
 }
 
@@ -570,6 +623,19 @@ func (cuo *CompanyUpdateOne) sqlSave(ctx context.Context) (_node *Company, err e
 		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: company.FieldProfileImage,
+		})
+	}
+	if value, ok := cuo.mutation.Hompage(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: company.FieldHompage,
+		})
+	}
+	if cuo.mutation.HompageCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Column: company.FieldHompage,
 		})
 	}
 	if cuo.mutation.UserCleared() {

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -81,6 +81,7 @@ var (
 		{Name: "address", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "profile_image", Type: field.TypeString, Nullable: true},
+		{Name: "hompage", Type: field.TypeString, Nullable: true},
 		{Name: "user_company", Type: field.TypeInt, Nullable: true},
 	}
 	// CompaniesTable holds the schema information for the "companies" table.
@@ -91,7 +92,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "companies_users_company",
-				Columns:    []*schema.Column{CompaniesColumns[6]},
+				Columns:    []*schema.Column{CompaniesColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -1249,6 +1249,7 @@ type CompanyMutation struct {
 	address         *string
 	description     *string
 	profile_image   *string
+	hompage         *string
 	clearedFields   map[string]struct{}
 	user            *int
 	cleareduser     bool
@@ -1561,6 +1562,55 @@ func (m *CompanyMutation) ResetProfileImage() {
 	delete(m.clearedFields, company.FieldProfileImage)
 }
 
+// SetHompage sets the "hompage" field.
+func (m *CompanyMutation) SetHompage(s string) {
+	m.hompage = &s
+}
+
+// Hompage returns the value of the "hompage" field in the mutation.
+func (m *CompanyMutation) Hompage() (r string, exists bool) {
+	v := m.hompage
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldHompage returns the old "hompage" field's value of the Company entity.
+// If the Company object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CompanyMutation) OldHompage(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldHompage is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldHompage requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldHompage: %w", err)
+	}
+	return oldValue.Hompage, nil
+}
+
+// ClearHompage clears the value of the "hompage" field.
+func (m *CompanyMutation) ClearHompage() {
+	m.hompage = nil
+	m.clearedFields[company.FieldHompage] = struct{}{}
+}
+
+// HompageCleared returns if the "hompage" field was cleared in this mutation.
+func (m *CompanyMutation) HompageCleared() bool {
+	_, ok := m.clearedFields[company.FieldHompage]
+	return ok
+}
+
+// ResetHompage resets all changes to the "hompage" field.
+func (m *CompanyMutation) ResetHompage() {
+	m.hompage = nil
+	delete(m.clearedFields, company.FieldHompage)
+}
+
 // SetUserID sets the "user" edge to the User entity by id.
 func (m *CompanyMutation) SetUserID(id int) {
 	m.user = &id
@@ -1619,7 +1669,7 @@ func (m *CompanyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CompanyMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.name != nil {
 		fields = append(fields, company.FieldName)
 	}
@@ -1634,6 +1684,9 @@ func (m *CompanyMutation) Fields() []string {
 	}
 	if m.profile_image != nil {
 		fields = append(fields, company.FieldProfileImage)
+	}
+	if m.hompage != nil {
+		fields = append(fields, company.FieldHompage)
 	}
 	return fields
 }
@@ -1653,6 +1706,8 @@ func (m *CompanyMutation) Field(name string) (ent.Value, bool) {
 		return m.Description()
 	case company.FieldProfileImage:
 		return m.ProfileImage()
+	case company.FieldHompage:
+		return m.Hompage()
 	}
 	return nil, false
 }
@@ -1672,6 +1727,8 @@ func (m *CompanyMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldDescription(ctx)
 	case company.FieldProfileImage:
 		return m.OldProfileImage(ctx)
+	case company.FieldHompage:
+		return m.OldHompage(ctx)
 	}
 	return nil, fmt.Errorf("unknown Company field %s", name)
 }
@@ -1716,6 +1773,13 @@ func (m *CompanyMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetProfileImage(v)
 		return nil
+	case company.FieldHompage:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetHompage(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Company field %s", name)
 }
@@ -1755,6 +1819,9 @@ func (m *CompanyMutation) ClearedFields() []string {
 	if m.FieldCleared(company.FieldProfileImage) {
 		fields = append(fields, company.FieldProfileImage)
 	}
+	if m.FieldCleared(company.FieldHompage) {
+		fields = append(fields, company.FieldHompage)
+	}
 	return fields
 }
 
@@ -1778,6 +1845,9 @@ func (m *CompanyMutation) ClearField(name string) error {
 	case company.FieldProfileImage:
 		m.ClearProfileImage()
 		return nil
+	case company.FieldHompage:
+		m.ClearHompage()
+		return nil
 	}
 	return fmt.Errorf("unknown Company nullable field %s", name)
 }
@@ -1800,6 +1870,9 @@ func (m *CompanyMutation) ResetField(name string) error {
 		return nil
 	case company.FieldProfileImage:
 		m.ResetProfileImage()
+		return nil
+	case company.FieldHompage:
+		m.ResetHompage()
 		return nil
 	}
 	return fmt.Errorf("unknown Company field %s", name)

--- a/api/ent/schema/company.go
+++ b/api/ent/schema/company.go
@@ -20,6 +20,7 @@ func (Company) Fields() []ent.Field {
 		field.String("address").Optional().Nillable(),
 		field.String("description").Optional().Nillable(),
 		field.String("profile_image").Optional().Nillable(),
+		field.String("hompage").Optional().Nillable(),
 	}
 }
 

--- a/api/repository/company.go
+++ b/api/repository/company.go
@@ -40,12 +40,51 @@ func (r *companyRepository) Save(reqCompany *ent.Company) (*ent.Company, error) 
 	return c, nil
 }
 
-func (r *companyRepository) GetByID(companyID int, reqStudent *ent.Company) (*ent.Company, error) {
+func (r *companyRepository) GetByID(companyID int, reqCompany *ent.Company) (*ent.Company, error) {
 	c, err := r.db.Company.Query().
 		Where(company.ID(companyID)).
+		WithUser().
 		Only(context.Background())
 	if err != nil {
 		return nil, err
+	}
+
+	return c, nil
+}
+
+func (r *companyRepository) UploadProfileImage(reqCompany *ent.Company) (*ent.Company, error) {
+	c, err := r.db.Company.UpdateOneID(reqCompany.ID).
+		SetNillableProfileImage(reqCompany.ProfileImage).Save(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return c, nil
+}
+
+func (r *companyRepository) UpdateProfile(reqCompany *ent.Company) (*ent.Company, error) {
+	c, err := r.db.Company.UpdateOneID(reqCompany.ID).
+		SetNillableHompage(reqCompany.Hompage).
+		SetNillableDescription(reqCompany.Description).Save(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	user, err := c.QueryUser().First(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	c.Edges.User = user
+
+	return c, nil
+}
+
+func (r *companyRepository) GetAll(limit, offset int) ([]*ent.Company, error) {
+	c, err := r.db.Company.Query().WithUser().
+		Limit(limit).Offset(offset).All(context.Background())
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
 
 	return c, nil

--- a/api/service/company.go
+++ b/api/service/company.go
@@ -1,8 +1,18 @@
 package service
 
 import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/Wanted-Linx/linx-backend/api/domain"
 	"github.com/Wanted-Linx/linx-backend/api/ent"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -34,7 +44,126 @@ func (s *companyService) Save(userID int, reqSignup *domain.SignUpRequest) (*dom
 	return domain.CompanyToDto(newCompany), nil
 }
 
-func (s *companyService) GetCompanyByID(studentID int) (*domain.CompanyDto, error) {
+func (s *companyService) GetCompanyByID(companyID int) (*domain.CompanyDto, error) {
+	company := &ent.Company{
+		ID: companyID,
+	}
 
-	return nil, nil
+	c, err := s.companyRepo.GetByID(companyID, company)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, errors.WithMessage(err, "해당하는 기업을 찾을 수 없습니다.")
+		}
+		return nil, errors.WithMessage(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	log.Info("해당하는 기업 조회 완료", c)
+	return domain.CompanyToDto(c), nil
+}
+
+func (s *companyService) GetAllCompanies(limit, offset int) ([]*domain.CompanyDto, error) {
+	companies, err := s.companyRepo.GetAll(limit, offset)
+	if err != nil {
+		return nil, errors.WithMessage(err, "알 수 없는 오류가 발생했습니다.")
+	}
+
+	log.Info("기업들 조회 완료", companies)
+	return domain.CompaniesToDto(companies), nil
+}
+
+func (s *companyService) UpdateProfile(companyID int, reqCompany *domain.CompanyProfileUpdate) (*domain.CompanyDto, error) {
+	company := &ent.Company{
+		ID:          companyID,
+		Hompage:     &reqCompany.Homepage,
+		Description: &reqCompany.Description,
+	}
+
+	// TODO: business type에 대한 처리도 추후에...
+
+	updatedCompany, err := s.companyRepo.UpdateProfile(company)
+	if err != nil {
+		return nil, errors.WithMessage(err, "알 수 없는 에러가 발생했습니다.")
+	}
+
+	return domain.CompanyToDto(updatedCompany), nil
+}
+func (s *companyService) UploadProfileImage(companyID int, reqImage *domain.CompanyProfileImage) ([]byte, error) {
+	var fileBytes []byte
+
+	// TODO: profile upload 함수 공통이므로 따로 빼기...
+	for _, imageFile := range reqImage.Image {
+		// Source
+		src, err := imageFile.Open()
+		if err != nil {
+			return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+		}
+		defer src.Close()
+
+		fileBytes, err = ioutil.ReadAll(src)
+		if err != nil {
+			return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+		}
+
+		// Destination
+		dir := fmt.Sprintf("./companies/profile/%d/image", companyID)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			os.MkdirAll(dir, 0700) // Create your file
+		}
+
+		// image 저장 위치 uuid 값을 key로...
+		key := uuid.New().String()
+		dst, err := os.Create(filepath.Join(dir, filepath.Base(key)))
+		if err != nil {
+			return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+		}
+		defer dst.Close()
+
+		img, fileType, err := image.Decode(bytes.NewReader(fileBytes))
+		if err != nil {
+			return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+		}
+
+		switch fileType {
+		case "jpeg":
+			log.Println(fileType)
+			err = jpeg.Encode(dst, img, nil)
+			if err != nil {
+				return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+			}
+		default:
+			err = png.Encode(dst, img)
+			if err != nil {
+				return nil, errors.Wrap(err, "프로필 이미지 업로드 실패")
+			}
+		}
+
+		company := &ent.Company{
+			ID:           companyID,
+			ProfileImage: &key,
+		}
+
+		c, err := s.companyRepo.UploadProfileImage(company)
+		if err != nil {
+			return nil, errors.WithMessage(err, "프로필 이미지 업로드 실패")
+		}
+
+		log.Info("프로필 이미지 업로드 성공", c)
+	}
+
+	return fileBytes, nil
+}
+
+func (s *companyService) GetProfileImage(companyID int) ([]byte, error) {
+	company, err := s.GetCompanyByID(companyID)
+	if err != nil {
+		return nil, err
+	}
+
+	fileBytes, err := ioutil.ReadFile(fmt.Sprintf("./companies/profile/%d/image/%s", companyID, *company.ProfileImage))
+	if err != nil {
+		return nil, errors.Wrap(err, "프로필 이미지 조회 실패")
+	}
+
+	log.Info("프로필 이미지 조회 완료", company)
+	return fileBytes, nil
 }


### PR DESCRIPTION
**PR요약**
- 학생과 마찬가지로 기업 프로필과 조회 구현
- `business type`에 대한 처리를 추후에 해야 함
- 프로필 이미지 업로드 프로세스는 학생, 클럽, 기업 동일하므로 추후에 한 메소드로 빼줄 예정